### PR TITLE
Some settings moved to the backend and added RainLab.Sitemap support

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,8 +1,10 @@
 <?php namespace Tiipiik\Booking;
 
 use Backend;
+use Event;
 use System\Classes\PluginBase;
 use Tiipiik\Booking\Classes\TagProcessor;
+use Tiipiik\Booking\Models\Room;
 
 /**
  * Booking Plugin Information File
@@ -55,11 +57,15 @@ class Plugin extends PluginBase
             ],
             'tiipiik.booking.access_rooms' => [
                 'tab' => 'tiipiik.booking::lang.permissions.tab',
-                'label' => 'tiipiik.booking::lang.permissions.bookings'
+                'label' => 'tiipiik.booking::lang.permissions.rooms'
             ],
             'tiipiik.booking.access_payplans' => [
                 'tab' => 'tiipiik.booking::lang.permissions.tab',
-                'label' => 'tiipiik.booking::lang.permissions.bookings'
+                'label' => 'tiipiik.booking::lang.permissions.payplans'
+            ],
+            'tiipiik.booking.manage_settings' => [
+                'tab' => 'tiipiik.booking::lang.permissions.tab',
+                'label' => 'tiipiik.booking::lang.permissions.settings'
             ],
         ];
 	} 
@@ -98,6 +104,20 @@ class Plugin extends PluginBase
         ];
     }
 
+    public function registerSettings()
+    {
+        return [
+            'config' => [
+                'label'       => 'tiipiik.booking::lang.plugin_name',
+                'icon'        => 'icon-list',
+                'description' => 'tiipiik.booking::lang.settings_description',
+                'class'       => 'Tiipiik\Booking\Models\Settings',
+                'permissions' => ['tiipiik.booking.manage_settings'],
+                'keywords'    => 'room booking pay plans'
+            ]
+        ];
+    }
+
     /**
      * Register method, called when the plugin is first registered.
      */
@@ -121,6 +141,28 @@ class Plugin extends PluginBase
                     <input type="file" class="trigger"/>
                 </span>', 
             $input);
+        });
+    }
+
+    public function boot()
+    {
+        /*
+         * Register menu items for the RainLab.Pages and RainLab.Sitemap plugin
+         */
+        Event::listen('pages.menuitem.listTypes', function() {
+            return [
+                'all-rooms' => 'All rooms',
+            ];
+        });
+
+        Event::listen('pages.menuitem.getTypeInfo', function($type) {
+            if ($type == 'all-rooms')
+                return Room::getMenuTypeInfo($type);
+        });
+
+        Event::listen('pages.menuitem.resolveItem', function($type, $item, $url, $theme) {
+            if ($type == 'all-rooms')
+                return Room::resolveMenuItem($item, $url, $theme);
         });
     }
 }

--- a/components/RoomList.php
+++ b/components/RoomList.php
@@ -4,6 +4,7 @@ use App;
 use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use Tiipiik\Booking\Models\Room;
+use Tiipiik\Booking\Models\Settings;
 
 class RoomList extends ComponentBase
 {
@@ -32,18 +33,6 @@ class RoomList extends ComponentBase
                 'type'        => 'string',
                 'default'     => ':page',
             ],
-            'roomPage' => [
-                'title'       => 'tiipiik.booking::lang.components.room_list.params.room_page_title',
-                'description' => 'tiipiik.booking::lang.components.room_list.params.room_page_desc',
-                'type'        => 'dropdown',
-                'default'     => 'booking/room'
-            ],
-            'room_page_slug' => [
-                'title'       => 'tiipiik.booking::lang.components.room_list.params.room_slug_title',
-                'description' => 'tiipiik.booking::lang.components.room_list.params.room_slug_desc',
-                'type'        => 'string',
-                'default'     => '{{ :slug }}',
-            ],
             'noRoomsMessage' => [
                 'title'        => 'tiipiik.booking::lang.components.room_list.params.no_room_title',
                 'description'  => 'tiipiik.booking::lang.components.room_list.params.no_room_desc',
@@ -66,14 +55,14 @@ class RoomList extends ComponentBase
         //$this->themePath = $this->page['themePath'] = $this->themeUrl();
         
         $this->roomParam = $this->page['roomParam'] = $this->property('roomParam');
-        $this->roomPage = $this->page['roomPage'] = $this->property('roomPage');
-        $this->room_page_slug = $this->page['room_page_slug'] = $this->property('room_page_slug');
+        $this->roomPage = $this->page['roomPage'] = Settings::get('roomPage');
+        $this->room_page_slug = $this->page['room_page_slug'] = Settings::get('room_page_slug');
     }
     
     protected function listRooms()
     {
         return Room::make()->listFrontEnd([
-            'room' => $this->property('room_page_slug'),
+            'room' => Settings::get('room_page_slug'),
         ]);
     }
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -3,8 +3,9 @@
 return [
     'plugin_name' => 'Booking',
     'plugin_description' => 'Room Booking plugin, with front and backend',
+    'settings_description' => 'Configure Tiipiik room booking plugin',
     'booking' => [
-        'amount'=>'Amoont',
+        'amount'=>'Amount',
         'currency'=>'Currency',
         'validated'=>'Validated',
         'registered'=>'Registered',
@@ -117,5 +118,6 @@ return [
         'bookings' => 'Manage bookings',
         'rooms' => 'Manage rooms',
         'payplans' => 'Manage pay plans',
+        'settings' => 'Manage settings',
     ],
 ];

--- a/models/Room.php
+++ b/models/Room.php
@@ -7,6 +7,8 @@ use Markdown;
 use ValidationException;
 use Tiipiik\Booking\Classes\TagProcessor;
 use Cms\Classes\Controller as BaseController;
+use Tiipiik\Booking\Models\Settings;
+use Url;
 
 /**
  * Room Model
@@ -148,6 +150,47 @@ class Room extends Model
     public function beforeSave()
     {
         $this->content_html = self::formatHtml($this->content);
+    }
+
+    /**
+     * Handler for the pages.menuitem.getTypeInfo event.
+     * Returns a menu item type information. The type information is returned as array
+     */
+    public static function getMenuTypeInfo($type)
+    {
+        return [
+            'dynamicItems' => true
+        ];
+    }
+
+    /**
+     * Handler for the pages.menuitem.resolveItem event.
+     * Returns information about a menu item. The result is an array
+     */
+    public static function resolveMenuItem($item, $url, $theme)
+    {
+        $result = [
+            'items' => []
+        ];
+
+        $rooms = self::orderBy('name')->get();
+        $roomPage = Settings::get('roomPage');
+
+        foreach ($rooms as $room) {
+            $fullSlug = $roomPage .'/'. $room->slug;
+
+            $roomItem = [
+                'title' => $room->name,
+                'url'   => Url::action('Cms\Classes\Controller@run', ['slug' => $fullSlug]),
+                'mtime' => $room->updated_at,
+            ];
+
+            $roomItem['isActive'] = $roomItem['url'] == $url;
+
+            $result['items'][] = $roomItem;
+        }
+
+        return $result;
     }
 
 }

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,0 +1,28 @@
+<?php namespace Tiipiik\Booking\Models;
+
+use October\Rain\Database\Model;
+
+/**
+ * Tiipiik Booking plugin settings model
+ *
+ * @package system
+ * @author Matiss Janis Aboltins <matiss@mja.lv>
+ */
+class Settings extends Model
+{
+    use \October\Rain\Database\Traits\Validation;
+
+    public $implement = ['System.Behaviors.SettingsModel'];
+
+    public $settingsCode = 'tiipiik_booking_settings';
+
+    public $settingsFields = 'fields.yaml';
+
+    /**
+     * Validation rules
+     */
+    public $rules = [
+        'roomPage' => 'required',
+        'room_page_slug' => 'required',
+    ];
+}

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -1,0 +1,14 @@
+fields:
+    roomPage:
+        span: left
+        label: tiipiik.booking::lang.components.room_list.params.room_page_title
+        comment: tiipiik.booking::lang.components.room_list.params.room_page_desc
+        default: booking/room
+        placeholder: booking/room
+
+    room_page_slug:
+        span: right
+        label: tiipiik.booking::lang.components.room_list.params.room_slug_title
+        comment: tiipiik.booking::lang.components.room_list.params.room_slug_desc
+        default: '{{ :slug }}'
+        placeholder: '{{ :slug }}'

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -46,3 +46,5 @@
     - Fix booked dates of each room
 1.1.3:
     - RC compatibilty update
+1.1.4:
+    - Some settings were moved to the backend and added RainLab.Sitemap support. PR by @matissjanis


### PR DESCRIPTION
The `roomPage` and `room_page_slug` settings were moved to the backend to bring some concurrency in page routes.

I use `[room_list]` component all around my site in many places. That means that in every place where I use it - I must define `roomPage`. If or when I change my mind and want to change the route to something else - I have to go around all these places changing the parameter. This update simply stores these two params in the database therefore making the routes much more concurrent.

This update features as well RainLab.Sitemap support.

Hope this makes it in to the codebase! :)
