### PR TITLE
Room full description can now be translated

### DIFF
--- a/models/room/fields.yaml
+++ b/models/room/fields.yaml
@@ -32,22 +32,14 @@ secondaryTabs:
     fields:
         content:
             tab: tiipiik.booking::lang.room.backend.description_tab_title
-            stretch: true
-            span: left
-            cssClass: no-padding
-            type: codeeditor
-            language: markdown
-            showGutter: false
-            wrapWords: true
-            fontSize: 13
-            margin: 15
+            type: richeditor
 
-        preview:
-            type: Tiipiik\Booking\FormWidgets\Preview
-            tab: tiipiik.booking::lang.room.backend.description_tab_title
-            stretch: true
-            span: right
-            cssClass: no-padding
+        # preview:
+        #     type: Tiipiik\Booking\FormWidgets\Preview
+        #     tab: tiipiik.booking::lang.room.backend.description_tab_title
+        #     stretch: true
+        #     span: right
+        #     cssClass: no-padding
     
         excerpt:
             tab: tiipiik.booking::lang.room.backend.manage_tab_title


### PR DESCRIPTION
So far this is the quickest way of making content translatable. The downside to using richeditor is that the toolbar buttons are useless since they produce html content instead of markdown.

I am trying all day to get markdown editor to work with translate-plugin but I am missing something...
