### PR TITLE
Fix for incorrect booked date array.

### DIFF
--- a/models/Booking.php
+++ b/models/Booking.php
@@ -146,7 +146,7 @@ class Booking extends Model
                 // for each booked day, add entry in the array
                 for ($i=1;$i<=$diffInDays;$i++)
                 {
-                    $nextDate = $aDate->addDay()->format("Y-m-d");
+                    $nextDate = $aDate->format("Y-m-d");
                     $nextDate = explode('-', $nextDate);
                     
                     // Place year into array
@@ -166,6 +166,8 @@ class Booking extends Model
                     {
                         $bookedDates[ (int) $nextDate[0] ][ (int) $nextDate[1] ][] = (int) $nextDate[2];
                     }
+                    
+                    $aDate->addDay();
                 } 
             }
         }


### PR DESCRIPTION
If you have a date period from 27.03 to 05.04; before it would mark on calendar that 27.03 is free, but 05.04 is booked. Now it shows that 27.03 is booked and 05.04 is free for booking.
