### PR TITLE
Fix YAML files paths

### DIFF
--- a/controllers/bookings/config_form.yaml
+++ b/controllers/bookings/config_form.yaml
@@ -6,7 +6,7 @@
 name: Room Booking
 
 # Model Form Field configuration
-form: @/plugins/tiipiik/booking/models/booking/fields.yaml
+form: ~/plugins/tiipiik/booking/models/booking/fields.yaml
 
 # Model Class name
 modelClass: Tiipiik\Booking\Models\Booking

--- a/controllers/bookings/config_list.yaml
+++ b/controllers/bookings/config_list.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 # Model List Column configuration
-list: @/plugins/tiipiik/booking/models/booking/columns.yaml
+list: ~/plugins/tiipiik/booking/models/booking/columns.yaml
 
 # Model Class name
 modelClass: Tiipiik\Booking\Models\Booking

--- a/controllers/payplans/config_form.yaml
+++ b/controllers/payplans/config_form.yaml
@@ -6,7 +6,7 @@
 name: PayPlan
 
 # Model Form Field configuration
-form: @/plugins/tiipiik/booking/models/payplan/fields.yaml
+form: ~/plugins/tiipiik/booking/models/payplan/fields.yaml
 
 # Model Class name
 modelClass: Tiipiik\Booking\Models\PayPlan

--- a/controllers/payplans/config_list.yaml
+++ b/controllers/payplans/config_list.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 # Model List Column configuration
-list: @/plugins/tiipiik/booking/models/payplan/columns.yaml
+list: ~/plugins/tiipiik/booking/models/payplan/columns.yaml
 
 # Model Class name
 modelClass: Tiipiik\Booking\Models\PayPlan

--- a/controllers/rooms/config_form.yaml
+++ b/controllers/rooms/config_form.yaml
@@ -6,7 +6,7 @@
 name: Room
 
 # Model Form Field configuration
-form: @/plugins/tiipiik/booking/models/room/fields.yaml
+form: ~/plugins/tiipiik/booking/models/room/fields.yaml
 
 # Model Class name
 modelClass: Tiipiik\Booking\Models\Room

--- a/controllers/rooms/config_list.yaml
+++ b/controllers/rooms/config_list.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 # Model List Column configuration
-list: @/plugins/tiipiik/booking/models/room/columns.yaml
+list: ~/plugins/tiipiik/booking/models/room/columns.yaml
 
 # Model Class name
 modelClass: Tiipiik\Booking\Models\Room

--- a/models/booking/columns.yaml
+++ b/models/booking/columns.yaml
@@ -52,7 +52,7 @@ columns:
         label: tiipiik.booking::lang.booking.backend.columns.pay_plan
         invisible: true
         relation: PayPlan
-        select: @title
+        select: title
         
     comment:
         label: tiipiik.booking::lang.booking.backend.columns.comment


### PR DESCRIPTION
Fix YAML paths, right syntax is with `~`, see for example https://github.com/rainlab/blog-plugin/blob/master/controllers/categories/config_list.yaml#L6

![snimek obrazovky 2016-04-07 v 14 27 31](https://cloud.githubusercontent.com/assets/374917/14351196/4029755a-fcce-11e5-8eb0-3ae636dee686.png)
