### PR TITLE
Workaround for amount and total_nights

### DIFF
--- a/models/booking/fields.yaml
+++ b/models/booking/fields.yaml
@@ -83,12 +83,14 @@ secondaryTabs:
             label: tiipiik.booking::lang.booking.backend.stay.nights
             span: left
             cssClass: col-sm-4
+            default: 0
             
         amount:
             tab: tiipiik.booking::lang.booking.backend.pay_plan.tab_title
             label: tiipiik.booking::lang.booking.amount
             span: left
             cssClass: col-sm-4
+            default: 0
             
         currency:
             tab: tiipiik.booking::lang.booking.backend.pay_plan.tab_title


### PR DESCRIPTION
In newer versions of mysql it throws an exception saying that `amount` and `total_nights` are incorrect integer values when not manually entering them. This enables the user not to enter those values and submit the form.